### PR TITLE
[Feat] : 카카오 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ dependencies {
 
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/donet/donet/DonetApplication.java
+++ b/src/main/java/com/donet/donet/DonetApplication.java
@@ -2,7 +2,9 @@ package com.donet.donet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DonetApplication {
 

--- a/src/main/java/com/donet/donet/auth/adapter/in/web/LoginController.java
+++ b/src/main/java/com/donet/donet/auth/adapter/in/web/LoginController.java
@@ -1,0 +1,20 @@
+package com.donet.donet.auth.adapter.in.web;
+
+import com.donet.donet.auth.application.port.in.LoginCommand;
+import com.donet.donet.auth.application.port.in.LoginResponse;
+import com.donet.donet.auth.application.port.in.LoginUsecase;
+import com.donet.donet.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class LoginController {
+    private final LoginUsecase loginUsecase;
+
+    @PostMapping("/auth/login/kakao")
+    public BaseResponse<LoginResponse> kakaoLogin(String code){
+        return new BaseResponse<>(loginUsecase.login(new LoginCommand(code)));
+    }
+}

--- a/src/main/java/com/donet/donet/auth/adapter/in/web/LoginController.java
+++ b/src/main/java/com/donet/donet/auth/adapter/in/web/LoginController.java
@@ -4,8 +4,10 @@ import com.donet.donet.auth.application.port.in.LoginCommand;
 import com.donet.donet.auth.application.port.in.LoginResponse;
 import com.donet.donet.auth.application.port.in.LoginUsecase;
 import com.donet.donet.global.response.BaseResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -14,7 +16,7 @@ public class LoginController {
     private final LoginUsecase loginUsecase;
 
     @PostMapping("/auth/login/kakao")
-    public BaseResponse<LoginResponse> kakaoLogin(String code){
+    public BaseResponse<LoginResponse> kakaoLogin(@RequestParam("code") @NotBlank String code){
         return new BaseResponse<>(loginUsecase.login(new LoginCommand(code)));
     }
 }

--- a/src/main/java/com/donet/donet/auth/adapter/out/oauth/KakaoAuthClient.java
+++ b/src/main/java/com/donet/donet/auth/adapter/out/oauth/KakaoAuthClient.java
@@ -1,0 +1,65 @@
+package com.donet.donet.auth.adapter.out.oauth;
+
+import com.donet.donet.auth.application.port.out.KakaoAuthPort;
+import com.donet.donet.auth.application.port.out.KakaoOAuthToken;
+import com.donet.donet.auth.application.port.out.KakaoUserProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthClient implements KakaoAuthPort {
+    @Value("${app.kakao.auth.client}") private String client;
+    @Value("${app.kakao.auth.redirect}") private String redirect;
+
+    @Override
+    public KakaoOAuthToken requestToken(String accessCode) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_url", redirect);
+        params.add("code", accessCode);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        ResponseEntity<KakaoOAuthToken> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                KakaoOAuthToken.class);
+
+        return response.getBody();
+    }
+
+    @Override
+    public KakaoUserProfile requestUserProfile(KakaoOAuthToken oAuthToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization","Bearer "+ oAuthToken.access_token());
+
+        HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity <>(headers);
+
+        ResponseEntity<KakaoUserProfile> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                kakaoProfileRequest,
+                KakaoUserProfile.class);
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/donet/donet/auth/adapter/out/oauth/KakaoAuthClient.java
+++ b/src/main/java/com/donet/donet/auth/adapter/out/oauth/KakaoAuthClient.java
@@ -3,16 +3,20 @@ package com.donet.donet.auth.adapter.out.oauth;
 import com.donet.donet.auth.application.port.out.KakaoAuthPort;
 import com.donet.donet.auth.application.port.out.KakaoOAuthToken;
 import com.donet.donet.auth.application.port.out.KakaoUserProfile;
+import com.donet.donet.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import static com.donet.donet.global.response.status.BaseExceptionResponseStatus.OAUTH_SERVER_UNAVAILABLE;
 
 
 @Component
@@ -21,16 +25,24 @@ public class KakaoAuthClient implements KakaoAuthPort {
     @Value("${app.kakao.auth.client}") private String client;
     @Value("${app.kakao.auth.redirect}") private String redirect;
 
+    private RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+        return new RestTemplate(factory);
+    }
+
     @Override
     public KakaoOAuthToken requestToken(String accessCode) {
-        RestTemplate restTemplate = new RestTemplate();
+        RestTemplate restTemplate = restTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Accept", "application/json");
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", client);
-        params.add("redirect_url", redirect);
+        params.add("redirect_uri", redirect);
         params.add("code", accessCode);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
@@ -41,16 +53,25 @@ public class KakaoAuthClient implements KakaoAuthPort {
                 kakaoTokenRequest,
                 KakaoOAuthToken.class);
 
-        return response.getBody();
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(OAUTH_SERVER_UNAVAILABLE);
+        }
+
+        KakaoOAuthToken body = response.getBody();
+        if(body == null){
+            throw new CustomException(OAUTH_SERVER_UNAVAILABLE);
+        }
+        return body;
     }
 
     @Override
     public KakaoUserProfile requestUserProfile(KakaoOAuthToken oAuthToken) {
-        RestTemplate restTemplate = new RestTemplate();
+        RestTemplate restTemplate = restTemplate();
         HttpHeaders headers = new HttpHeaders();
 
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         headers.add("Authorization","Bearer "+ oAuthToken.access_token());
+        headers.add("Accept", "application/json");
 
         HttpEntity<MultiValueMap<String,String>> kakaoProfileRequest = new HttpEntity <>(headers);
 
@@ -60,6 +81,14 @@ public class KakaoAuthClient implements KakaoAuthPort {
                 kakaoProfileRequest,
                 KakaoUserProfile.class);
 
-        return response.getBody();
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(OAUTH_SERVER_UNAVAILABLE);
+        }
+
+        KakaoUserProfile body = response.getBody();
+        if(body == null){
+            throw new CustomException(OAUTH_SERVER_UNAVAILABLE);
+        }
+        return body;
     }
 }

--- a/src/main/java/com/donet/donet/auth/application/LoginService.java
+++ b/src/main/java/com/donet/donet/auth/application/LoginService.java
@@ -27,14 +27,13 @@ public class LoginService implements LoginUsecase {
     public LoginResponse login(LoginCommand loginCommand) {
         String code = loginCommand.code();
         KakaoOAuthToken oAuthToken = kakaoAuthPort.requestToken(code);
-        log.info("access_token = {}", oAuthToken.access_token() );
-
         KakaoUserProfile userProfile = kakaoAuthPort.requestUserProfile(oAuthToken);
-        log.info("kakaoId = {}", userProfile.id());
 
         // 신규 회원이면 가입시킨다
         User user = findUserUsecase.findByLoginId(userProfile.id())
                 .orElseGet(()-> registerUser(userProfile));
+
+        log.info("[login] userId = {}인 사용자가 조회됨", user.getId());
 
         String accessToken = tokenIssuerPort.createAccessToken(user.getId());
         String refreshToken = tokenIssuerPort.createRefreshToken(user.getId());
@@ -42,7 +41,7 @@ public class LoginService implements LoginUsecase {
     }
 
     private User registerUser(KakaoUserProfile userProfile){
-        log.info("User not found. Create a new User");
+        log.info("[registerUser] 첫 로그인 사용자를 새로운 유저로 등록");
         User newUser = new User(null,
                 userProfile.properties().nickname(),
                 userProfile.kakao_account().profile().thumbnail_image_url(),

--- a/src/main/java/com/donet/donet/auth/application/LoginService.java
+++ b/src/main/java/com/donet/donet/auth/application/LoginService.java
@@ -1,0 +1,53 @@
+package com.donet.donet.auth.application;
+
+import com.donet.donet.auth.application.port.in.LoginCommand;
+import com.donet.donet.auth.application.port.in.LoginResponse;
+import com.donet.donet.auth.application.port.in.LoginUsecase;
+import com.donet.donet.auth.application.port.out.KakaoAuthPort;
+import com.donet.donet.auth.application.port.out.KakaoOAuthToken;
+import com.donet.donet.auth.application.port.out.KakaoUserProfile;
+import com.donet.donet.auth.application.port.out.TokenIssuerPort;
+import com.donet.donet.user.application.port.in.CreateUserUsecase;
+import com.donet.donet.user.application.port.in.FindUserUsecase;
+import com.donet.donet.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService implements LoginUsecase {
+    private final KakaoAuthPort kakaoAuthPort;
+    private final FindUserUsecase findUserUsecase;
+    private final CreateUserUsecase createUserUsecase;
+    private final TokenIssuerPort tokenIssuerPort;
+
+    @Override
+    public LoginResponse login(LoginCommand loginCommand) {
+        String code = loginCommand.code();
+        KakaoOAuthToken oAuthToken = kakaoAuthPort.requestToken(code);
+        log.info("access_token = {}", oAuthToken.access_token() );
+
+        KakaoUserProfile userProfile = kakaoAuthPort.requestUserProfile(oAuthToken);
+        log.info("kakaoId = {}", userProfile.id());
+
+        // 신규 회원이면 가입시킨다
+        User user = findUserUsecase.findByLoginId(userProfile.id())
+                .orElseGet(()-> registerUser(userProfile));
+
+        String accessToken = tokenIssuerPort.createAccessToken(user.getId());
+        String refreshToken = tokenIssuerPort.createRefreshToken(user.getId());
+        return new LoginResponse(accessToken, refreshToken);
+    }
+
+    private User registerUser(KakaoUserProfile userProfile){
+        log.info("User not found. Create a new User");
+        User newUser = new User(null,
+                userProfile.properties().nickname(),
+                userProfile.kakao_account().profile().thumbnail_image_url(),
+                "KAKAO",
+                userProfile.id());
+        return createUserUsecase.save(newUser);
+    }
+}

--- a/src/main/java/com/donet/donet/auth/application/port/in/LoginCommand.java
+++ b/src/main/java/com/donet/donet/auth/application/port/in/LoginCommand.java
@@ -1,0 +1,6 @@
+package com.donet.donet.auth.application.port.in;
+
+public record LoginCommand(
+        String code
+) {
+}

--- a/src/main/java/com/donet/donet/auth/application/port/in/LoginResponse.java
+++ b/src/main/java/com/donet/donet/auth/application/port/in/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.donet.donet.auth.application.port.in;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/donet/donet/auth/application/port/in/LoginUsecase.java
+++ b/src/main/java/com/donet/donet/auth/application/port/in/LoginUsecase.java
@@ -1,0 +1,5 @@
+package com.donet.donet.auth.application.port.in;
+
+public interface LoginUsecase {
+    LoginResponse login(LoginCommand loginCommand);
+}

--- a/src/main/java/com/donet/donet/auth/application/port/out/KakaoAuthPort.java
+++ b/src/main/java/com/donet/donet/auth/application/port/out/KakaoAuthPort.java
@@ -1,0 +1,7 @@
+package com.donet.donet.auth.application.port.out;
+
+public interface KakaoAuthPort {
+    KakaoOAuthToken requestToken(String code);
+
+    KakaoUserProfile requestUserProfile(KakaoOAuthToken oAuthToken);
+}

--- a/src/main/java/com/donet/donet/auth/application/port/out/KakaoOAuthToken.java
+++ b/src/main/java/com/donet/donet/auth/application/port/out/KakaoOAuthToken.java
@@ -1,0 +1,11 @@
+package com.donet.donet.auth.application.port.out;
+
+public record KakaoOAuthToken(
+        String access_token,
+        String token_type,
+        String refresh_token,
+        int expires_in,
+        String scope,
+        int refresh_token_expires_in
+) {
+}

--- a/src/main/java/com/donet/donet/auth/application/port/out/KakaoUserProfile.java
+++ b/src/main/java/com/donet/donet/auth/application/port/out/KakaoUserProfile.java
@@ -1,0 +1,29 @@
+package com.donet.donet.auth.application.port.out;
+
+public record KakaoUserProfile(
+        String id,
+        String connected_at,
+        Properties properties,
+        KakaoAccount kakao_account
+) {
+    public record Properties(
+            String nickname
+    ) {}
+
+    public record KakaoAccount(
+            String email,
+            Boolean is_email_verified,
+            Boolean has_email,
+            Boolean profile_nickname_needs_agreement,
+            Boolean email_needs_agreement,
+            Boolean is_email_valid,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname,
+                Boolean is_default_nickname,
+                String thumbnail_image_url
+        ) {}
+    }
+}
+

--- a/src/main/java/com/donet/donet/auth/application/port/out/TokenIssuerPort.java
+++ b/src/main/java/com/donet/donet/auth/application/port/out/TokenIssuerPort.java
@@ -1,0 +1,7 @@
+package com.donet.donet.auth.application.port.out;
+
+public interface TokenIssuerPort {
+    String createAccessToken(Long userId);
+
+    String createRefreshToken(Long userId);
+}

--- a/src/main/java/com/donet/donet/global/exception/CustomException.java
+++ b/src/main/java/com/donet/donet/global/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.donet.donet.global.exception;
+
+import com.donet.donet.global.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public CustomException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
@@ -1,0 +1,107 @@
+package com.donet.donet.global.exception_handler;
+
+import com.donet.donet.global.exception.CustomException;
+import com.donet.donet.global.response.BaseErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import static com.donet.donet.global.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    /**
+     * 숫자/boolean 등의 타입이 일치하지 않는 경우 발생하는 Hibernate 예외 처리
+     * 주로 잘못된 파라미터 변환 시 발생 (ex. boolean 필드에 문자열 전달)
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(TypeMismatchException.class)
+    public BaseErrorResponse handle_TypeMismatchException(TypeMismatchException e){
+        log.error("[handle_TypeMismatchException]", e);
+        return new BaseErrorResponse(BAD_REQUEST);
+    }
+
+    /**
+     * 존재하지 않는 API 경로로 요청했을 때 발생 (404 Not Found)
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
+        log.error("[handle_NoHandlerFoundException]", e);
+        return new BaseErrorResponse(API_NOT_FOUND);
+    }
+
+    /**
+     * 처리되지 않은 런타임 예외를 전역적으로 처리
+     * 서버 내부 오류(500 Internal Server Error) 응답 반환
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public BaseErrorResponse handle_RuntimeException(RuntimeException e) {
+        log.error("[handle_RuntimeException]", e);
+        return new BaseErrorResponse(INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * @Valid 또는 @Validated를 통해 DTO 필드 유효성 검사에 실패한 경우 처리
+     * (e.g., 필수값 누락, 길이 초과 등)
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public BaseErrorResponse handle_MethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("[handle_MethodArgumentNotValidException]", e);
+        FieldError fieldError = e.getBindingResult().getFieldError(); // NPE 가능성으로 인해 검증
+        String defaultMessage = (fieldError != null) ? e.getBindingResult().getFieldError().getDefaultMessage() : "Invalid request";
+        return new BaseErrorResponse(BAD_REQUEST, defaultMessage);
+    }
+
+    /**
+     * @RequestParam 필드가 아예 전달되지 않은 경우 처리
+     * (e.g., 필수 쿼리 파라미터 누락)
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public BaseErrorResponse handle_MissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.error("[handle_MissingServletRequestParameterException]", e);
+        String message = String.format("필수 요청 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+        return new BaseErrorResponse(BAD_REQUEST, message);
+    }
+
+    /**
+     * @RequestParam, @PathVariable 등에서 enum/숫자 등의 타입 변환이 실패한 경우 처리
+     * (e.g., 잘못된 enum 값, 숫자 자리에 문자열 입력 등)
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public BaseErrorResponse handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.error("[handleMethodArgumentTypeMismatch]", e);
+
+        String name = e.getName();  // 파라미터 이름
+        String value = e.getValue() != null ? e.getValue().toString() : "null";
+        String message = String.format("잘못된 '%s' 파라미터 값입니다. 입력값: '%s'", name, value);
+
+        return new BaseErrorResponse(BAD_REQUEST, message);
+    }
+
+    /**
+     * 프로젝트 내부에서 발생한 CustomException 처리
+     * 각 예외가 담고 있는 커스텀 응답 코드와 메시지를 그대로 반환
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<BaseErrorResponse> handle_CustomException(CustomException e) {
+        log.error("[handle_CustomException]", e);
+        return ResponseEntity.status(e.getExceptionStatus().getStatus())
+                .body(new BaseErrorResponse(e.getExceptionStatus()));
+    }
+}

--- a/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -95,9 +96,19 @@ public class GlobalControllerAdvice {
     }
 
     /**
-     * 프로젝트 내부에서 발생한 CustomException 처리
-     * 각 예외가 담고 있는 커스텀 응답 코드와 메시지를 그대로 반환
+     * @RequestParam, @PathVariable, @RequestHeader, @ModelAttribute 등에 붙인
+     * Bean Validation(@NotBlank, @Min 등)이 실패했을 때
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public BaseErrorResponse handle_HandlerMethodValidationException(HandlerMethodValidationException e) {
+        log.error("[handle_HandlerMethodValidationException]", e);
+        return new BaseErrorResponse(BAD_REQUEST);
+    }
+        /**
+         * 프로젝트 내부에서 발생한 CustomException 처리
+         * 각 예외가 담고 있는 커스텀 응답 코드와 메시지를 그대로 반환
+         */
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<BaseErrorResponse> handle_CustomException(CustomException e) {
         log.error("[handle_CustomException]", e);

--- a/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/donet/donet/global/exception_handler/GlobalControllerAdvice.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import static com.donet.donet.global.response.status.BaseExceptionResponseStatus.*;
 
@@ -36,9 +36,9 @@ public class GlobalControllerAdvice {
      * 존재하지 않는 API 경로로 요청했을 때 발생 (404 Not Found)
      */
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(NoHandlerFoundException.class)
-    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
-        log.error("[handle_NoHandlerFoundException]", e);
+    @ExceptionHandler(NoResourceFoundException.class) // Spring 6 전용 예외 (404 발생 시)
+    public BaseErrorResponse handle_NoResourceFoundException(NoResourceFoundException e) {
+        log.error("[handle_NoResourceFoundException] {} {} ", e.getHttpMethod(), e.getResourcePath());
         return new BaseErrorResponse(API_NOT_FOUND);
     }
 

--- a/src/main/java/com/donet/donet/global/jwt/JwtUtil.java
+++ b/src/main/java/com/donet/donet/global/jwt/JwtUtil.java
@@ -1,0 +1,67 @@
+package com.donet.donet.global.jwt;
+
+import com.donet.donet.auth.application.port.out.TokenIssuerPort;
+import com.donet.donet.global.jwt.exception.InvalidJwtException;
+import com.donet.donet.global.jwt.exception.JwtExpiredException;
+import com.donet.donet.global.jwt.exception.JwtNotFoundException;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static com.donet.donet.global.response.status.BaseExceptionResponseStatus.*;
+
+@Component
+public class JwtUtil implements TokenIssuerPort {
+    private final SecretKey secretKey;
+    private final long accessTokenExpireMs;
+    private final long refreshTokenExpireMs;
+
+    public JwtUtil(@Value("${app.jwt.secret-key}") String secret,
+                   @Value("${app.jwt.access-expire-ms}") long accessTokenExpireMs,
+                   @Value("${app.jwt.refresh-expire-ms}") long refreshTokenExpireMs) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.accessTokenExpireMs = accessTokenExpireMs;
+        this.refreshTokenExpireMs = refreshTokenExpireMs;
+    }
+
+    @Override
+    public String createAccessToken(Long userId) {
+        return Jwts.builder()
+                .claim("user_id", userId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @Override
+    public String createRefreshToken(Long userId) {
+        return Jwts.builder()
+                .claim("user_id", userId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims validateToken(String token){
+        try{
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+        } catch (MalformedJwtException e) {
+            throw new InvalidJwtException(INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new JwtExpiredException(EXPIRED_JWT);
+        } catch (UnsupportedJwtException e) {
+            throw new InvalidJwtException(INVALID_JWT);
+        } catch (SecurityException e) {
+            throw new InvalidJwtException(INVALID_JWT);
+        } catch (IllegalArgumentException e) {
+            throw new JwtNotFoundException(JWT_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/donet/donet/global/jwt/exception/InvalidJwtException.java
+++ b/src/main/java/com/donet/donet/global/jwt/exception/InvalidJwtException.java
@@ -1,0 +1,10 @@
+package com.donet.donet.global.jwt.exception;
+
+import com.donet.donet.global.exception.CustomException;
+import com.donet.donet.global.response.status.ResponseStatus;
+
+public class InvalidJwtException extends CustomException {
+    public InvalidJwtException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/donet/donet/global/jwt/exception/JwtExpiredException.java
+++ b/src/main/java/com/donet/donet/global/jwt/exception/JwtExpiredException.java
@@ -1,0 +1,10 @@
+package com.donet.donet.global.jwt.exception;
+
+import com.donet.donet.global.exception.CustomException;
+import com.donet.donet.global.response.status.ResponseStatus;
+
+public class JwtExpiredException extends CustomException {
+    public JwtExpiredException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/donet/donet/global/jwt/exception/JwtNotFoundException.java
+++ b/src/main/java/com/donet/donet/global/jwt/exception/JwtNotFoundException.java
@@ -1,0 +1,10 @@
+package com.donet.donet.global.jwt.exception;
+
+import com.donet.donet.global.exception.CustomException;
+import com.donet.donet.global.response.status.ResponseStatus;
+
+public class JwtNotFoundException extends CustomException {
+    public JwtNotFoundException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/donet/donet/global/persistence/BaseEntity.java
+++ b/src/main/java/com/donet/donet/global/persistence/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.donet.donet.global.persistence;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BaseStatus status = BaseStatus.ACTIVE;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/donet/donet/global/persistence/BaseStatus.java
+++ b/src/main/java/com/donet/donet/global/persistence/BaseStatus.java
@@ -1,0 +1,5 @@
+package com.donet.donet.global.persistence;
+
+public enum BaseStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/donet/donet/global/response/BaseErrorResponse.java
+++ b/src/main/java/com/donet/donet/global/response/BaseErrorResponse.java
@@ -1,0 +1,66 @@
+package com.donet.donet.global.response;
+
+import com.donet.donet.global.response.status.ResponseStatus;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"status", "code", "message", "timestamp"})
+public class BaseErrorResponse implements ResponseStatus {
+    @Schema(example = "400")
+    private final int status;
+
+    @Schema(example = "4000")
+    private final int code;
+
+    @Schema(example = "요청에 실패하였습니다.")
+    private final String message;
+
+    @Schema(example = "2025-01-01 00:00:00")
+    private final LocalDateTime timestamp;
+
+    @JsonCreator
+    public BaseErrorResponse(
+            @JsonProperty("status") int status,
+            @JsonProperty("code") int code,
+            @JsonProperty("message") String message,
+            @JsonProperty("timestamp") LocalDateTime timestamp
+    ) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public BaseErrorResponse(ResponseStatus status) {
+        this.status = status.getStatus();
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public BaseErrorResponse(ResponseStatus status, String message) {
+        this.status = status.getStatus();
+        this.code = status.getCode();
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/donet/donet/global/response/BaseResponse.java
+++ b/src/main/java/com/donet/donet/global/response/BaseResponse.java
@@ -1,0 +1,45 @@
+package com.donet.donet.global.response;
+
+import com.donet.donet.global.response.status.ResponseStatus;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static com.donet.donet.global.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+
+@Getter
+@JsonPropertyOrder({"status", "code", "message", "data"})
+public class BaseResponse<T> implements ResponseStatus {
+    @Schema(example = "200")
+    private final int status;
+
+    @Schema(example = "2000")
+    private final int code;
+
+    @Schema(example = "요청에 성공하였습니다.")
+    private final String message;
+
+    private final T data;
+
+    public BaseResponse(T data) {
+        this.status = HttpStatus.OK.value();
+        this.code = SUCCESS.getCode();
+        this.message = SUCCESS.getMessage();
+        this.data = data;
+    }
+
+    @Override
+    public int getStatus(){
+        return this.status;
+    }
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/donet/donet/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/donet/donet/global/response/status/BaseExceptionResponseStatus.java
@@ -1,0 +1,40 @@
+package com.donet.donet.global.response.status;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum BaseExceptionResponseStatus implements ResponseStatus{
+    // 1000 : 성공 및 공통 에러
+    SUCCESS(HttpStatus.OK.value(), 1000, "요청에 성공했습니다."),
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(),1001, "유효하지 않은 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), 1002, "인증 자격이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), 1003, "권한이 없습니다."),
+    API_NOT_FOUND(HttpStatus.NOT_FOUND.value(),1004, "존재하지 않는 API입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), 1005, "유효하지 않은 Http 메서드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 1006, "서버 내부 오류입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED.value(), 1007, "올바르지 않은 토큰입니다."),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED.value(), 1008, "만료된 토큰입니다"),
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), 1009, "토큰을 찾을 수 없습니다");
+
+    private final int status;
+    private final int code;
+    private final String message;
+
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/donet/donet/global/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/donet/donet/global/response/status/BaseExceptionResponseStatus.java
@@ -16,7 +16,10 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 1006, "서버 내부 오류입니다."),
     INVALID_JWT(HttpStatus.UNAUTHORIZED.value(), 1007, "올바르지 않은 토큰입니다."),
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED.value(), 1008, "만료된 토큰입니다"),
-    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), 1009, "토큰을 찾을 수 없습니다");
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), 1009, "토큰을 찾을 수 없습니다"),
+
+    // 2000 : Auth 관련 에러
+    OAUTH_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), 2001, "OAuth 제공자 서버로 인해 요청을 처리할 수 없습니다");
 
     private final int status;
     private final int code;

--- a/src/main/java/com/donet/donet/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/donet/donet/global/response/status/ResponseStatus.java
@@ -1,0 +1,10 @@
+package com.donet.donet.global.response.status;
+
+public interface ResponseStatus {
+    int getStatus();
+
+    int getCode();
+
+    String getMessage();
+
+}

--- a/src/main/java/com/donet/donet/home/adapter/in/web/MainPageController.java
+++ b/src/main/java/com/donet/donet/home/adapter/in/web/MainPageController.java
@@ -1,6 +1,5 @@
-package com.donet.donet;
+package com.donet.donet.home.adapter.in.web;
 
-import com.donet.donet.dto.ResponseMainPageDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,8 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("")
-public class Controller {
-
+public class MainPageController {
     @Operation(summary = "메인페이지", description = "메인 페이지 조회 API입니다.")
     @GetMapping("/main")
     public ResponseMainPageDTO mainPage(){

--- a/src/main/java/com/donet/donet/home/adapter/in/web/ResponseMainPageDTO.java
+++ b/src/main/java/com/donet/donet/home/adapter/in/web/ResponseMainPageDTO.java
@@ -1,4 +1,4 @@
-package com.donet.donet.dto;
+package com.donet.donet.home.adapter.in.web;
 
 import java.util.List;
 

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserEntityMapper.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserEntityMapper.java
@@ -12,4 +12,12 @@ public class UserEntityMapper {
                 jpaEntity.getLoginProvider(),
                 jpaEntity.getLoginId());
     }
+
+    public UserJpaEntity mapToJpaEntity(User entity){
+        return new UserJpaEntity(null,
+                entity.getNickname(),
+                entity.getProfileImage(),
+                entity.getLoginProvider(),
+                entity.getLoginId());
+    }
 }

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserEntityMapper.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserEntityMapper.java
@@ -1,0 +1,15 @@
+package com.donet.donet.user.adapter.out.persistence;
+
+import com.donet.donet.user.domain.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserEntityMapper {
+    public User mapToDomainEntity(UserJpaEntity jpaEntity) {
+        return new User(jpaEntity.getId(),
+                jpaEntity.getNickname(),
+                jpaEntity.getProfileImage(),
+                jpaEntity.getLoginProvider(),
+                jpaEntity.getLoginId());
+    }
+}

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserJpaEntity.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserJpaEntity.java
@@ -1,0 +1,30 @@
+package com.donet.donet.user.adapter.out.persistence;
+
+import com.donet.donet.global.persistence.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class UserJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String profileImage;
+
+    @Column(nullable = false)
+    private String loginProvider;
+
+    @Column(nullable = false)
+    private String loginId;
+}

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
-public class UserPersistenceAdapter implements FindUserPort {
+public class UserPersistenceAdapter implements FindUserPort, CreateUserPort {
     private final UserRepository userRepository;
     private final UserEntityMapper userEntityMapper;
 
@@ -21,5 +21,12 @@ public class UserPersistenceAdapter implements FindUserPort {
                     return Optional.of(userEntityMapper.mapToDomainEntity(userJpaEntity));
                 })
                 .orElseGet(() -> Optional.empty());
+    }
+
+    @Override
+    public User save(User user) {
+        UserJpaEntity jpaEntity = userEntityMapper.mapToJpaEntity(user);
+        UserJpaEntity save = userRepository.save(jpaEntity);
+        return userEntityMapper.mapToDomainEntity(save);
     }
 }

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.donet.donet.user.adapter.out.persistence;
+
+import com.donet.donet.user.application.out.CreateUserPort;
+import com.donet.donet.user.application.port.out.FindUserPort;
+import com.donet.donet.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class UserPersistenceAdapter implements FindUserPort {
+    private final UserRepository userRepository;
+    private final UserEntityMapper userEntityMapper;
+
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return userRepository.findByLoginId(loginId)
+                .map(userJpaEntity -> {
+                    return Optional.of(userEntityMapper.mapToDomainEntity(userJpaEntity));
+                })
+                .orElseGet(() -> Optional.empty());
+    }
+}

--- a/src/main/java/com/donet/donet/user/adapter/out/persistence/UserRepository.java
+++ b/src/main/java/com/donet/donet/user/adapter/out/persistence/UserRepository.java
@@ -1,0 +1,9 @@
+package com.donet.donet.user.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
+    Optional<UserJpaEntity> findByLoginId(String loginId);
+}

--- a/src/main/java/com/donet/donet/user/application/CreateUserService.java
+++ b/src/main/java/com/donet/donet/user/application/CreateUserService.java
@@ -1,0 +1,17 @@
+package com.donet.donet.user.application;
+
+import com.donet.donet.user.application.out.CreateUserPort;
+import com.donet.donet.user.application.port.in.CreateUserUsecase;
+import com.donet.donet.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CreateUserService implements CreateUserUsecase {
+    private final CreateUserPort createUserPort;
+    @Override
+    public User save(User newUser) {
+        return createUserPort.save(newUser);
+    }
+}

--- a/src/main/java/com/donet/donet/user/application/FindUserService.java
+++ b/src/main/java/com/donet/donet/user/application/FindUserService.java
@@ -1,0 +1,19 @@
+package com.donet.donet.user.application;
+
+import com.donet.donet.user.application.port.in.FindUserUsecase;
+import com.donet.donet.user.application.port.out.FindUserPort;
+import com.donet.donet.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserService implements FindUserUsecase {
+    private final FindUserPort findUserPort;
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return findUserPort.findByLoginId(loginId);
+    }
+}

--- a/src/main/java/com/donet/donet/user/application/out/CreateUserPort.java
+++ b/src/main/java/com/donet/donet/user/application/out/CreateUserPort.java
@@ -1,0 +1,7 @@
+package com.donet.donet.user.application.out;
+
+import com.donet.donet.user.domain.User;
+
+public interface CreateUserPort {
+    User save(User newUser);
+}

--- a/src/main/java/com/donet/donet/user/application/port/in/CreateUserUsecase.java
+++ b/src/main/java/com/donet/donet/user/application/port/in/CreateUserUsecase.java
@@ -1,0 +1,7 @@
+package com.donet.donet.user.application.port.in;
+
+import com.donet.donet.user.domain.User;
+
+public interface CreateUserUsecase {
+    User save(User newUser);
+}

--- a/src/main/java/com/donet/donet/user/application/port/in/FindUserUsecase.java
+++ b/src/main/java/com/donet/donet/user/application/port/in/FindUserUsecase.java
@@ -1,0 +1,9 @@
+package com.donet.donet.user.application.port.in;
+
+import com.donet.donet.user.domain.User;
+
+import java.util.Optional;
+
+public interface FindUserUsecase {
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/donet/donet/user/application/port/out/FindUserPort.java
+++ b/src/main/java/com/donet/donet/user/application/port/out/FindUserPort.java
@@ -1,0 +1,9 @@
+package com.donet.donet.user.application.port.out;
+
+import com.donet.donet.user.domain.User;
+
+import java.util.Optional;
+
+public interface FindUserPort {
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/donet/donet/user/domain/User.java
+++ b/src/main/java/com/donet/donet/user/domain/User.java
@@ -1,0 +1,14 @@
+package com.donet.donet.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class User {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private String loginProvider;
+    private String loginId;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,16 @@ spring:
     activate:
       on-profile: common
 
+app:
+  kakao:
+    auth:
+      client: ${KAKAO_APP_KEY}
+      redirect: ${KAKAO_REDIRECT_URL}
+  jwt:
+    access-expire-ms: ${JWT_ACCESS_EXPIRE_MS}
+    refresh-expire-ms : ${JWT_REFRESH_EXPIRE_MS}
+    secret-key: ${JWT_SECRET_KEY}
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,11 +47,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-        highlight_sql: true
 
 ---
 # 공통 속성

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,14 @@ spring:
     username: ${LOCAL_DB_USERNAME}
     password: ${LOCAL_DB_PASSWORD}
     driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
 
 ---
 # 배포용 DB 설정
@@ -36,6 +44,14 @@ spring:
     sql:
       init:
         platform: mysql
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
 
 ---
 # 공통 속성

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,4 +21,4 @@ app:
   jwt:
     access-expire-ms: 360000
     refresh-expire-ms : 3600000
-    secret-key: asdf1234asdf1234asdf1234asdf1234asdf1234
+    secret-key: asdf1234asdf1234asdf1234asdf1234asdf1234asdf1234asdf1234asdf1234asdf1234

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,21 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+
+app:
+  kakao:
+    auth:
+      client: asdf1234asdf1234asdf1234asdf1234asdf1234
+      redirect: http://localhost:8080/auth/login/kakao
+  jwt:
+    access-expire-ms: 360000
+    refresh-expire-ms : 3600000
+    secret-key: asdf1234asdf1234asdf1234asdf1234asdf1234


### PR DESCRIPTION
## 📌 PR 설명

<!-- PR의 목적과 변경 내용을 간단히 적어주세요. -->

카카오 소셜 로그인을 구현했습니다. 카카오 인증 서버와 직접 통신하는 방식입니다.

패키지는 헥사고날 아키텍처 방식으로 변경하였습니다. 
- 그런데 어느 특정 도메인에 속한다고 보기 어려운 GlobalControllerAdvice, JwtUtil, CustomException, BaseEntity, BaseResponse 등은 global이라는 패키지에 두었습니다. 
- 추후에 global 패키지의 구조와 제약사항에 대해서 논의를 해야할 것 같습니다.

## ✅ 작업 내용

- [ ] 카카오 소셜 로그인 기능 구현
- [ ] Donet 서버용 JWT 토큰 발급 구현

## 🔍 리뷰 요청 사항

<!-- 리뷰어에게 중점적으로 봐줬으면 하는 부분 -->
편하게 리뷰해주세요!

## 📷 스크린샷 (선택)

<!-- 변경된 UI나 동작 예시가 있다면 첨부 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 카카오 소셜 로그인 엔드포인트(/auth/login/kakao) 추가 — 액세스/리프레시 토큰 발급.
  - 카카오 OAuth 연동 및 사용자 조회/자동 등록 흐름, 토큰 생성(Access/Refresh) 구현.
  - 통합 API 응답(BaseResponse) 및 표준 오류 페이로드(BaseErrorResponse) 도입.
  - 전역 예외 처리기 추가로 일관된 오류 응답 제공.

- **Bug Fixes / Improvements**
  - JWT 생성·검증 유틸 및 관련 JWT 예외 추가.
  - JPA 감사(생성/수정 시각) 활성화 및 공통 엔터티 상태/타임스탬프 도입.

- **Refactor**
  - 메인 페이지 컨트롤러와 DTO 패키지/명칭 변경(경로 변경 없음).

- **Chores**
  - JWT 관련 의존성 및 카카오/JWT 환경 설정 추가.
  - 테스트용 애플리케이션 설정(로컬/테스트) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->