### PR TITLE
[Fix] 기부하기 API에서 생성된 기부 id 반환하도록 응답 DTO 수정

### DIFF
--- a/src/main/java/com/donet/donet/donation/adapter/in/web/CreateDonationController.java
+++ b/src/main/java/com/donet/donet/donation/adapter/in/web/CreateDonationController.java
@@ -1,6 +1,7 @@
 package com.donet.donet.donation.adapter.in.web;
 
 import com.donet.donet.donation.adapter.in.web.dto.CreateDonationRequest;
+import com.donet.donet.donation.adapter.in.web.dto.CreateDonationResponse;
 import com.donet.donet.donation.application.port.in.CreateDonationUsecase;
 import com.donet.donet.donation.application.port.in.dto.command.CreateDonationCommand;
 import com.donet.donet.global.annotation.CurrentUserId;
@@ -34,9 +35,9 @@ public class CreateDonationController implements DonationController{
     )
     @CustomExceptionDescription(DEFAULT)
     @PostMapping(path = "/register" ,consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public BaseResponse<Void> createDonation(@Parameter(hidden = true) @CurrentUserId Long userId,
-                                             @Parameter @RequestPart(required = false) List<MultipartFile> images,
-                                             @Parameter @RequestPart CreateDonationRequest request
+    public BaseResponse<CreateDonationResponse> createDonation(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                               @Parameter @RequestPart(required = false) List<MultipartFile> images,
+                                                               @Parameter @RequestPart CreateDonationRequest request
     ){
         CreateDonationCommand command = CreateDonationCommand.from(
                 userId,
@@ -52,7 +53,6 @@ public class CreateDonationController implements DonationController{
                 request.content()
         );
 
-        createDonationUsecase.createDonation(command);
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(createDonationUsecase.createDonation(command));
     }
 }

--- a/src/main/java/com/donet/donet/donation/adapter/in/web/dto/CreateDonationResponse.java
+++ b/src/main/java/com/donet/donet/donation/adapter/in/web/dto/CreateDonationResponse.java
@@ -1,0 +1,6 @@
+package com.donet.donet.donation.adapter.in.web.dto;
+
+public record CreateDonationResponse(
+        Long id
+) {
+}

--- a/src/main/java/com/donet/donet/donation/adapter/out/persistence/donation/DonationPersistenceAdapter.java
+++ b/src/main/java/com/donet/donet/donation/adapter/out/persistence/donation/DonationPersistenceAdapter.java
@@ -144,7 +144,7 @@ public class DonationPersistenceAdapter implements FindDonationPort, UpdateDonat
     }
 
     @Override
-    public void createDonation(Donation donation) {
+    public Long createDonation(Donation donation) {
         UserJpaEntity userJpaEntity = userRepository.findById(donation.getUserId())
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
@@ -182,5 +182,6 @@ public class DonationPersistenceAdapter implements FindDonationPort, UpdateDonat
                 });
 
         DonationJpaEntity savedDonation = donationRepository.save(donationJpaEntity);
+        return savedDonation.getId();
     }
 }

--- a/src/main/java/com/donet/donet/donation/application/CreateDonationService.java
+++ b/src/main/java/com/donet/donet/donation/application/CreateDonationService.java
@@ -1,5 +1,6 @@
 package com.donet.donet.donation.application;
 
+import com.donet.donet.donation.adapter.in.web.dto.CreateDonationResponse;
 import com.donet.donet.donation.application.port.in.CreateDonationUsecase;
 import com.donet.donet.donation.application.port.in.dto.command.CreateDonationCommand;
 import com.donet.donet.donation.application.port.out.CreateDonationPort;
@@ -20,7 +21,7 @@ public class CreateDonationService implements CreateDonationUsecase {
     private final ImageUploaderPort imageUploaderPort;
 
     @Override
-    public void createDonation(CreateDonationCommand command) {
+    public CreateDonationResponse createDonation(CreateDonationCommand command) {
         List<String> imagesUrls = Optional.ofNullable(command.images())
                 .orElseGet(List::of)
                 .stream()
@@ -61,6 +62,7 @@ public class CreateDonationService implements CreateDonationUsecase {
                 .categories(categories)
                 .build();
 
-        createDonationPort.createDonation(donation);
+        Long donationId = createDonationPort.createDonation(donation);
+        return new CreateDonationResponse(donationId);
     }
 }

--- a/src/main/java/com/donet/donet/donation/application/port/in/CreateDonationUsecase.java
+++ b/src/main/java/com/donet/donet/donation/application/port/in/CreateDonationUsecase.java
@@ -1,7 +1,8 @@
 package com.donet.donet.donation.application.port.in;
 
+import com.donet.donet.donation.adapter.in.web.dto.CreateDonationResponse;
 import com.donet.donet.donation.application.port.in.dto.command.CreateDonationCommand;
 
 public interface CreateDonationUsecase {
-    void createDonation(CreateDonationCommand command);
+    CreateDonationResponse createDonation(CreateDonationCommand command);
 }

--- a/src/main/java/com/donet/donet/donation/application/port/out/CreateDonationPort.java
+++ b/src/main/java/com/donet/donet/donation/application/port/out/CreateDonationPort.java
@@ -3,5 +3,5 @@ package com.donet.donet.donation.application.port.out;
 import com.donet.donet.donation.domain.Donation;
 
 public interface CreateDonationPort {
-    void createDonation(Donation donation);
+    Long createDonation(Donation donation);
 }


### PR DESCRIPTION
- close #76 

## 📌 PR 설명

<!-- PR의 목적과 변경 내용을 간단히 적어주세요. -->
기부하기 API에서 생성된 기부 id 반환하도록 응답 DTO 수정했습니다. 

## ✅ 작업 내용

- [x] 기부하기 API에서 생성된 기부 id 반환하도록 응답 DTO 수정

## 🔍 리뷰 요청 사항
없습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 기부 생성 API가 새로 생성된 기부의 ID를 반환하도록 개선되어, 사용자가 기부 생성 결과를 더욱 명확하게 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->